### PR TITLE
Python 2 support via __future__ imports

### DIFF
--- a/make_table.py
+++ b/make_table.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from argparse import ArgumentParser
 from glob import glob
 from os import path

--- a/src/data.py
+++ b/src/data.py
@@ -1,3 +1,10 @@
+from __future__ import division
+from __future__ import print_function
+try:
+	FileNotFoundError
+except NameError:
+	FileNotFoundError = OSError # Python 2
+
 from python_layers import PyLayer
 import numpy as np
 

--- a/src/python_layers.py
+++ b/src/python_layers.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from __future__ import print_function
 from caffe_all import *
 import numpy as np

--- a/src/solver.py
+++ b/src/solver.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from __future__ import print_function
 from caffe_all import *
 

--- a/src/train_cls.py
+++ b/src/train_cls.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import print_function
+
 # Train and evaluate a classification model for VOC2012
 import argparse
 import config

--- a/src/util.py
+++ b/src/util.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from __future__ import print_function
 import numpy as np
 


### PR DESCRIPTION
This adds support for Python 2.  (It was simpler for me than compiling Caffe with Python 3...)  Understand if you don't like the clutter though.  (Also I'm not sure all of the imports are strictly necessary -- can remove any unneeded ones if you like.)